### PR TITLE
add coolify host to allowed hosts

### DIFF
--- a/citizens_project/citizens_project/settings.py
+++ b/citizens_project/citizens_project/settings.py
@@ -33,7 +33,7 @@ GOOGLE_OAUTH2_CLIENT_SECRET = os.environ["GOOGLE_CLIENT_SECRET"]
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['server.wounds.staging.paas.ic.unicamp.br', 'localhost', '127.0.0.1']
 
 
 # Application definition


### PR DESCRIPTION
This is needed to allow coolify server to be accessed through the client