### PR TITLE
Fix: Comorbidity Payload Consistency and Patient Profile Edits

### DIFF
--- a/citizens_project/app_cicatrizando/serializers.py
+++ b/citizens_project/app_cicatrizando/serializers.py
@@ -83,16 +83,24 @@ class PatientsExistsSerializer(serializers.Serializer):
 class UpdateFieldsSerializer(serializers.Serializer):
 
     # Django user fields:
-    name = serializers.CharField(max_length=300)
-    
+    name = serializers.CharField(max_length=300, required=False)
+
     #WoundsUser fields:
-    state = serializers.CharField(required = False, max_length=2)
-    city = serializers.CharField(required = False, max_length=100)
+    state = serializers.CharField(required = False, max_length=2, allow_blank=True)
+    city = serializers.CharField(required = False, max_length=100, allow_blank=True)
+    birth_date = serializers.DateField(required=False, allow_null=True)
 
     #Patient/Provider fields:
-    contact_email = serializers.EmailField(max_length=50)
-    contact_phone = serializers.CharField(max_length=15) 
+    contact_email = serializers.EmailField(max_length=50, required=False, allow_null=True)
+    contact_phone = serializers.CharField(max_length=15, required=False, allow_null=True)
 
+    # Patient-only metrics:
+    gender = serializers.CharField(required=False, allow_blank=True, allow_null=True, max_length=1)
+    height = serializers.DecimalField(max_digits=4, decimal_places=2, required=False, allow_null=True)
+    weight = serializers.DecimalField(max_digits=5, decimal_places=2, required=False, allow_null=True)
+    smoking_status = serializers.CharField(required=False, allow_blank=True, allow_null=True, max_length=10)
+    alcohol_consumption = serializers.CharField(required=False, allow_blank=True, allow_null=True, max_length=10)
+    comorbidities = serializers.ListField(child=serializers.CharField(max_length=255), required=False)
     def validate_state(self, value):
         return validate_brazilian_state(value)
 

--- a/citizens_project/app_cicatrizando/views.py
+++ b/citizens_project/app_cicatrizando/views.py
@@ -619,7 +619,9 @@ class UpdateFieldsView(viewsets.ViewSet):
             wounds_user.state = data["state"]
         if data.get("city") and (data["city"] != ""):
             wounds_user.city = data["city"]
-        
+        if data.get("birth_date"):
+            wounds_user.birth_date = data["birth_date"]
+
         wounds_user.save()
 
         if wounds_user.role == WoundsUser.Provider:
@@ -636,6 +638,31 @@ class UpdateFieldsView(viewsets.ViewSet):
                 patient.contact_email = data["contact_email"]
             if data.get("contact_phone") is not None:
                 patient.contact_phone = data["contact_phone"]
+            
+            # Update metrics
+            if "gender" in data:
+                patient.gender = data["gender"]
+            if "height" in data:
+                patient.height = data["height"]
+            if "weight" in data:
+                patient.weight = data["weight"]
+            if "smoking_status" in data:
+                patient.smoking_status = data["smoking_status"]
+            if "alcohol_consumption" in data:
+                patient.alcohol_consumption = data["alcohol_consumption"]
+            
+            # Update comorbidities
+            if "comorbidities" in data:
+                comorbidities_to_add = []
+                for comorbidity_name in data['comorbidities']:
+                    try:
+                        comorbidity = Comorbidity.objects.get(name__iexact=comorbidity_name)
+                        comorbidities_to_add.append(comorbidity)
+                    except Comorbidity.DoesNotExist:
+                        continue
+                if comorbidities_to_add:
+                    patient.comorbidities.set(comorbidities_to_add)
+
             patient.save()
 
         return Response(status=status.HTTP_200_OK)

--- a/citizens_project/app_cicatrizando/views.py
+++ b/citizens_project/app_cicatrizando/views.py
@@ -573,13 +573,7 @@ class RegisterPatientComorbidityView(viewsets.ViewSet):
             return Response(status=status.HTTP_403_FORBIDDEN)
         
 
-        comorbidities_to_add = []
-        for comorbidity_name in data.get('comorbidities', []):
-            try:
-                comorbidity = Comorbidity.objects.get(name__iexact=comorbidity_name)
-            except Comorbidity.DoesNotExist:
-                return Response(status=status.HTTP_400_BAD_REQUEST)
-            comorbidities_to_add.append(comorbidity)
+        comorbidities_to_add = Comorbidity.objects.filter(concept_id__in=data.get('comorbidities', []))
 
         try:
             with transaction.atomic():
@@ -653,15 +647,8 @@ class UpdateFieldsView(viewsets.ViewSet):
             
             # Update comorbidities
             if "comorbidities" in data:
-                comorbidities_to_add = []
-                for comorbidity_name in data['comorbidities']:
-                    try:
-                        comorbidity = Comorbidity.objects.get(name__iexact=comorbidity_name)
-                        comorbidities_to_add.append(comorbidity)
-                    except Comorbidity.DoesNotExist:
-                        continue
-                if comorbidities_to_add:
-                    patient.comorbidities.set(comorbidities_to_add)
+                comorbidities = Comorbidity.objects.filter(concept_id__in=data["comorbidities"])
+                patient.comorbidities.set(comorbidities)
 
             patient.save()
 


### PR DESCRIPTION
This PR finalizes the patient onboarding and profile editing features.

### Fixes
- Unified the Comorbidity payload expectation: all endpoints (including 'UpdateFieldsView' and 'RegisterPatientComorbidityView') now consistently expect an array of 'concept_id' strings instead of names. This aligns the backend with the frontend's 'AsyncComorbiditySearch' behavior.
- Upgraded the 'UpdateFieldsView' to support modifying all clinical patient metrics (Height, Weight, Gender, Smoking Status, Alcohol Consumption, and Comorbidities). This allows patients to edit their entire profile from the dashboard.

### Cleanup
- Removed the 'is_profile_reviewed' field to maintain database compatibility and keep the patient update form completely optional.